### PR TITLE
Update .goreleaser.yaml

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -45,7 +45,7 @@ builds:
 archives:
   - id: default
     # ids: [pvetui, pvetui-windows-amd64]
-    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
     formats: ["tar.gz"]
     format_overrides:
       - goos: windows

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,10 +12,15 @@ builds:
     env:
       - CGO_ENABLED=0
     goos: [linux, darwin, windows]
-    goarch: [amd64, arm64, 386]
+    goarch: [amd64, arm64, 386, arm]
+    goarm: [6, 7]
     ignore:
       - goos: windows
         goarch: amd64
+      - goos: darwin
+        goarch: arm
+      - goos: windows
+        goarch: arm
     ldflags:
       - -s -w
       - -X github.com/devnullvoid/pvetui/internal/version.version={{.Version}}


### PR DESCRIPTION
Add armv7 armv6 support e.g. for the Orangepi embeded devices